### PR TITLE
Make crate no_std compatible.

### DIFF
--- a/src/bitwise_ops.rs
+++ b/src/bitwise_ops.rs
@@ -1,5 +1,5 @@
 //! Bitwise operations.  These should be equally fast in either endian.
-//! 
+//!
 //! ```rust
 //! // These should all be basically zero-cost:
 //! use simple_endian::*;
@@ -10,7 +10,7 @@
 //! a ^= 0x5555555.into();
 //! ```
 
-use std::ops::{BitAnd, Not, BitAndAssign, BitXor, BitXorAssign, BitOr, BitOrAssign};
+use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not};
 
 use super::*;
 
@@ -21,11 +21,13 @@ macro_rules! add_bitwise_ops {
         impl BitAnd for $wrap_ty {
             type Output = Self;
             fn bitand(self, rhs: Self) -> Self::Output {
-                Self{_v: self._v & rhs._v}
+                Self {
+                    _v: self._v & rhs._v,
+                }
             }
         }
         impl BitAndAssign for $wrap_ty {
-           fn bitand_assign(&mut self, rhs: Self) {
+            fn bitand_assign(&mut self, rhs: Self) {
                 *self = *self & rhs
             }
         }
@@ -34,7 +36,9 @@ macro_rules! add_bitwise_ops {
             type Output = Self;
 
             fn bitxor(self, rhs: Self) -> Self::Output {
-                Self{_v: self._v ^ rhs._v}
+                Self {
+                    _v: self._v ^ rhs._v,
+                }
             }
         }
         impl BitXorAssign for $wrap_ty {
@@ -46,7 +50,9 @@ macro_rules! add_bitwise_ops {
             type Output = Self;
 
             fn bitor(self, rhs: Self) -> Self {
-                Self{_v: self._v | rhs._v}
+                Self {
+                    _v: self._v | rhs._v,
+                }
             }
         }
         impl BitOrAssign for $wrap_ty {
@@ -58,10 +64,10 @@ macro_rules! add_bitwise_ops {
             type Output = Self;
 
             fn not(self) -> Self::Output {
-                Self{_v: !self._v}
+                Self { _v: !self._v }
             }
-        }        
-    }
+        }
+    };
 }
 
 #[cfg(feature = "byte_impls")]
@@ -82,7 +88,6 @@ mod bitwise_byte_ops {
         add_bitwise_ops!(LittleEndian<i8>);
     }
 }
-
 
 #[cfg(feature = "integer_impls")]
 mod bitwise_integer_ops {
@@ -114,7 +119,7 @@ mod bitwise_integer_ops {
         add_bitwise_ops!(LittleEndian<u128>);
         add_bitwise_ops!(LittleEndian<i128>);
         add_bitwise_ops!(LittleEndian<usize>);
-        add_bitwise_ops!(LittleEndian<isize>);  
+        add_bitwise_ops!(LittleEndian<isize>);
     }
 }
 
@@ -135,6 +140,4 @@ mod tests {
         let be1 = BigEndian::<u16>::from(0x0f0);
         assert_eq!(0xff0f, u16::from(!be1));
     }
-
-
 }

--- a/src/comparison_ops.rs
+++ b/src/comparison_ops.rs
@@ -1,6 +1,6 @@
 //! Comparison ops.
 #[allow(unused_imports)]
-use std::cmp::Ordering;
+use core::cmp::Ordering;
 
 #[allow(unused_imports)]
 use super::*;
@@ -14,8 +14,7 @@ macro_rules! add_equality_ops {
                 self.to_native().partial_cmp(&other.to_native())
             }
         }
-    
-    }
+    };
 }
 
 // The floats can only have PartialOrd, not Ord, because they only have PartialEq and not Eq.
@@ -36,8 +35,6 @@ mod float_comps {
     }
 }
 
-
-
 /// For types that implement Eq.
 #[allow(unused_macros)]
 macro_rules! add_full_equality_ops {
@@ -48,9 +45,8 @@ macro_rules! add_full_equality_ops {
             }
         }
         add_equality_ops!($wrap_ty);
-    }
+    };
 }
-
 
 // We have to separate Ord because f32/64 don't have Eq trait.
 #[cfg(feature = "integer_impls")]
@@ -105,9 +101,6 @@ mod byte_comps {
     }
 }
 
-
-
-
 #[cfg(test)]
 mod tests {
     extern crate test;
@@ -147,5 +140,4 @@ mod tests {
         let be2 = BigEndian::from(6234.5678);
         assert_eq!(true, be1 < be2);
     }
-
 }

--- a/src/formatting_ops.rs
+++ b/src/formatting_ops.rs
@@ -1,5 +1,5 @@
 //! Implementations for formatting the various types.
-use std::fmt::{Formatter, Result, UpperHex, LowerHex, Octal, Binary, Display};
+use core::fmt::{Binary, Display, Formatter, LowerHex, Octal, Result, UpperHex};
 
 use super::*;
 
@@ -13,7 +13,6 @@ impl<T: UpperHex + SpecificEndian<T>> UpperHex for LittleEndian<T> {
         write!(f, "{:X}", self.to_native()) // delegate to i32's implementation
     }
 }
-
 
 impl<T: LowerHex + SpecificEndian<T>> LowerHex for BigEndian<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 #![feature(test)]
 //! Many byte-order-handling libraries focus on providing code to convert to and from big- or little-endian.  However,
 //! this requires users of those libraries to use a lot of explicit logic.  This library uses the Rust type system to
@@ -5,7 +6,7 @@
 //! simply using the standard From and Into trait methods (from() and into()).  No explicit endian checks are required.
 //!  
 //! # Example 1:
-//! 
+//!
 //!```rust
 //! use simple_endian::*;
 //!
@@ -16,25 +17,25 @@
 //!         b: u32be,
 //!     }
 //!     let mut bp = BinPacket{a: 0xfe.into(), b: 10.into()};
-//!     let new_a = bp.a.to_native() * 1234; 
- 
+//!     let new_a = bp.a.to_native() * 1234;
+
 //!     bp.a = new_a.into();
 //!     bp.b = 1234.into();
 //! }
 //! ```
-//! 
+//!
 //! Trying to write `bp.a = new_a;` causes an error because the type u64 can't be directly stored.
-//! 
+//!
 //! # Example 2: Writing a portable struct to a file.
-//! 
+//!
 //! Of course, just storing things in memory isn't that useful unless you write somewhere.
-//! 
+//!
 //! ```rust
 //! use simple_endian::*;
 //! use std::fs::File;
 //! use std::io::prelude::*;
 //! use std::mem::{transmute, size_of};
-//! 
+//!
 //! // We have to specify a representation in order to define the layout.
 //! #[repr(C)]
 //! struct BinBEStruct {
@@ -42,7 +43,7 @@
 //!     b: u64be,
 //!     c: f64be,
 //! }
-//! 
+//!
 //! fn main() -> std::io::Result<()> {
 //!    let bin_struct = BinBEStruct{a: 345.into(), b: 0xfee.into(), c: 9.345.into()};
 //!
@@ -58,78 +59,84 @@
 //! }
 //! ```
 //! # Example 3: Mmapping a portable struct with the memmap crate.
-//! 
+//!
 //! You'll need to add memmap to your Cargo.toml to get this to actually work:
-//! 
+//!
 //! ```rust
 //! #![feature(rustc_private)]
 //! extern crate memmap;
-//! 
+//!
 //!  use std::{
 //!     io::Error,
 //!     fs::OpenOptions,
 //!     mem::size_of,
 //! };
-//! 
+//!
 //! use memmap::MmapOptions;
 //! use simple_endian::*;
-//! 
+//!
 //! #[repr(C)]
 //! struct MyBEStruct {
 //!     header: u64be,
 //!     label: [u8; 8],
 //!     count: u128be,
 //! }
-//! 
+//!
 //! fn main() -> Result<(), Error> {
 //!     let file = OpenOptions::new()
 //!         .read(true).write(true).create(true)
 //!         .open(".test.bin")?;
-//! 
+//!
 //!     // Truncate the file to the size of the header.
 //!     file.set_len(size_of::<MyBEStruct>() as u64)?;
 //!     let mut mmap = unsafe { MmapOptions::new().map_mut(&file)? };
-//! 
+//!
 //!     let mut ptr = mmap.as_mut_ptr() as *mut MyBEStruct;
-//! 
+//!
 //!     unsafe {
 //!         // Set the magic number
 //!         (*ptr).header = 0xfeedface.into();
-//! 
+//!
 //!         // Increment the counter each time we run.
 //!         (*ptr).count += 1.into();
-//! 
+//!
 //!         (*ptr).label = *b"Iamhere!";
 //!     }
-//! 
+//!
 //!     println!("done.");
 //!     Ok(())
 //! }
 //! ```
-//! 
+//!
 
-/// The main part of the library.  Contains the trait SpecificEndian<T> and BigEndian<T> and LittleEndian<T> structs, as well as the 
+/// The main part of the library.  Contains the trait SpecificEndian<T> and BigEndian<T> and LittleEndian<T> structs, as well as the
 /// implementation of those on the primitive types.
 mod specific_endian;
 pub use specific_endian::*;
 
 /// Bitwise operations.  These should be equally fast in any endian.
-#[cfg(feature = "bitwise")] mod bitwise_ops;
+#[cfg(feature = "bitwise")]
+mod bitwise_ops;
 
 /// Ops for comparisons and ordering.
-#[cfg(feature = "comparisons")] mod comparison_ops;
+#[cfg(feature = "comparisons")]
+mod comparison_ops;
 
 /// Shift operations.
-#[cfg(feature = "shift_ops")] mod shift_ops;
+#[cfg(feature = "shift_ops")]
+mod shift_ops;
 
 /// General math operations.
-#[cfg(feature = "math_ops")] mod math_ops;
+#[cfg(feature = "math_ops")]
+mod math_ops;
 
 /// Negations.
-#[cfg(feature = "neg_ops")] mod neg_ops;
+#[cfg(feature = "neg_ops")]
+mod neg_ops;
 
 /// Formatter impls.
-#[cfg(feature = "format")] mod formatting_ops;
+#[cfg(feature = "format")]
+mod formatting_ops;
 
 /// The shorthand types (e.g u64be, f32le, etc)
 mod shorthand_types;
@@ -151,7 +158,7 @@ mod tests {
                 a *= BigEndian::from(123);
                 a /= BigEndian::from(543);
             }
-            println!("{}", a);
+            test::black_box(a);
         });
     }
     #[bench]
@@ -164,7 +171,7 @@ mod tests {
                 a *= LittleEndian::from(123);
                 a /= LittleEndian::from(543);
             }
-            println!("{}", a);
+            test::black_box(a);
         });
     }
     #[bench]
@@ -177,7 +184,7 @@ mod tests {
                 a *= 123;
                 a /= 543;
             }
-            println!("{}", a);
+            test::black_box(a);
         });
     }
 
@@ -190,7 +197,7 @@ mod tests {
                 a *= BigEndian::from(123.0);
                 a /= BigEndian::from(543.0);
             }
-            println!("{}", a);
+            test::black_box(a);
         });
     }
     #[bench]
@@ -202,7 +209,7 @@ mod tests {
                 a *= LittleEndian::from(123.0);
                 a /= LittleEndian::from(543.0);
             }
-            println!("{}", a);
+            test::black_box(a);
         });
     }
     #[bench]
@@ -214,7 +221,7 @@ mod tests {
                 a *= 123.0;
                 a /= 543.0;
             }
-            println!("{}", a);
+            test::black_box(a);
         });
     }
 
@@ -222,8 +229,8 @@ mod tests {
     fn base_endian_test_be(b: &mut Bencher) {
         b.iter(|| {
             for _ in 0..1000 {
-               let a = i32::from_be(0xa5a5a5);
-               println!("{}", a);
+                let a = i32::from_be(0xa5a5a5);
+                test::black_box(a);
             }
         });
     }
@@ -231,8 +238,8 @@ mod tests {
     fn base_endian_test_le(b: &mut Bencher) {
         b.iter(|| {
             for _ in 0..1000 {
-               let a = i32::from_le(0xa5a5a5);
-               println!("{}", a);
+                let a = i32::from_le(0xa5a5a5);
+                test::black_box(a);
             }
         });
     }
@@ -240,8 +247,8 @@ mod tests {
     fn base_endian_test_ne(b: &mut Bencher) {
         b.iter(|| {
             for _ in 0..1000 {
-               let a = 0xa5a5a5_i32;
-               println!("{}", a);
+                let a = 0xa5a5a5_i32;
+                test::black_box(a);
             }
         });
     }
@@ -249,10 +256,9 @@ mod tests {
     fn base_endian_test_structured(b: &mut Bencher) {
         b.iter(|| {
             for _ in 0..1000 {
-               let a = LittleEndian{_v: 0xa5a5a5_i32};
-               println!("{}", a);
+                let a = LittleEndian { _v: 0xa5a5a5_i32 };
+                test::black_box(a);
             }
         });
     }
-    
 }

--- a/src/math_ops.rs
+++ b/src/math_ops.rs
@@ -1,6 +1,6 @@
 //! The math operations.  These all have some cost because they require conversion to native endian.
 #[allow(unused_imports)]
-use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
 #[allow(unused_imports)]
 use super::*;
@@ -62,8 +62,7 @@ macro_rules! add_math_ops {
                 *self = *self - other;
             }
         }
-
-    }
+    };
 }
 
 #[cfg(feature = "big_endian")]
@@ -73,7 +72,7 @@ mod be {
     mod bytes {
         use super::*;
         add_math_ops!(BigEndian<u8>);
-        add_math_ops!(BigEndian<i8>);    
+        add_math_ops!(BigEndian<i8>);
     }
 
     #[cfg(feature = "integer_impls")]
@@ -88,14 +87,14 @@ mod be {
         add_math_ops!(BigEndian<u128>);
         add_math_ops!(BigEndian<i128>);
         add_math_ops!(BigEndian<usize>);
-        add_math_ops!(BigEndian<isize>);    
+        add_math_ops!(BigEndian<isize>);
     }
 
     #[cfg(feature = "float_impls")]
     mod floats {
         use super::*;
         add_math_ops!(BigEndian<f32>);
-        add_math_ops!(BigEndian<f64>);    
+        add_math_ops!(BigEndian<f64>);
     }
 }
 
@@ -171,6 +170,4 @@ mod tests {
         ne1 /= 10.0;
         assert_eq!(ne1, be1.into());
     }
-
-
 }

--- a/src/neg_ops.rs
+++ b/src/neg_ops.rs
@@ -1,6 +1,6 @@
 //! Module adding negation to the types where it's possible.
 #[allow(unused_imports)]
-use std::ops::Neg;
+use core::ops::Neg;
 
 #[allow(unused_imports)]
 use super::*;
@@ -15,13 +15,14 @@ macro_rules! add_neg_ops {
                 Self::from(-self.to_native())
             }
         }
-    }
+    };
 }
 
 #[cfg(feature = "big_endian")]
 mod be {
     use super::*;
-    #[cfg(feature = "byte_impls")] add_neg_ops!(BigEndian<i8>);
+    #[cfg(feature = "byte_impls")]
+    add_neg_ops!(BigEndian<i8>);
 
     #[cfg(feature = "integer_impls")]
     mod integers {
@@ -41,11 +42,11 @@ mod be {
     }
 }
 
-
 #[cfg(feature = "little_endian")]
 mod le {
     use super::*;
-    #[cfg(feature = "byte_impls")] add_neg_ops!(LittleEndian<i8>);
+    #[cfg(feature = "byte_impls")]
+    add_neg_ops!(LittleEndian<i8>);
 
     #[cfg(feature = "integer_impls")]
     mod integers {
@@ -65,7 +66,6 @@ mod le {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     extern crate test;
@@ -73,16 +73,11 @@ mod tests {
     #[test]
     fn negate() {
         let be1 = BigEndian::from(1);
-        let be2 = -be1;
-        println!("{}, {}", be1, be2);
-        assert_eq!(be2, i32be::from(-1));
+        assert_eq!(-be1, i32be::from(-1));
     }
     #[test]
     fn negate_fp() {
         let be1 = BigEndian::from(1.0);
-        let be2 = -be1;
-        println!("{}, {}", be1, be2);
-        assert_eq!(be2, f64be::from(-1.0));
+        assert_eq!(-be1, f64be::from(-1.0));
     }
-
 }

--- a/src/shift_ops.rs
+++ b/src/shift_ops.rs
@@ -1,7 +1,7 @@
 //! Bitshift operations, for integer types only.
 
 #[allow(unused_imports)]
-use std::ops::{Shl, ShlAssign, Shr, ShrAssign};
+use core::ops::{Shl, ShlAssign, Shr, ShrAssign};
 
 #[allow(unused_imports)]
 use super::*;
@@ -11,7 +11,7 @@ macro_rules! add_shift_ops {
     ($wrap_ty:ty) => {
         impl Shl for $wrap_ty {
             type Output = Self;
-        
+
             fn shl(self, other: Self) -> Self {
                 Self::from(self.to_native() << other.to_native())
             }
@@ -23,7 +23,7 @@ macro_rules! add_shift_ops {
         }
         impl Shr for $wrap_ty {
             type Output = Self;
-        
+
             fn shr(self, other: Self) -> Self {
                 Self::from(self.to_native() >> other.to_native())
             }
@@ -33,17 +33,17 @@ macro_rules! add_shift_ops {
                 *self = Self::from((*self).to_native() >> rhs.to_native());
             }
         }
-    }
+    };
 }
 
 #[cfg(feature = "big_endian")]
 mod be {
     use super::*;
-    #[cfg(feature = "byte_impls")] 
+    #[cfg(feature = "byte_impls")]
     mod bytes {
         use super::*;
         add_shift_ops!(BigEndian<u8>);
-        add_shift_ops!(BigEndian<i8>);        
+        add_shift_ops!(BigEndian<i8>);
     }
 
     #[cfg(feature = "integer_impls")]
@@ -62,15 +62,14 @@ mod be {
     }
 }
 
-
 #[cfg(feature = "big_endian")]
 mod le {
     use super::*;
-    #[cfg(feature = "byte_impls")] 
+    #[cfg(feature = "byte_impls")]
     mod bytes {
         use super::*;
         add_shift_ops!(LittleEndian<u8>);
-        add_shift_ops!(LittleEndian<i8>);     
+        add_shift_ops!(LittleEndian<i8>);
     }
 
     #[cfg(feature = "integer_impls")]
@@ -85,7 +84,7 @@ mod le {
         add_shift_ops!(LittleEndian<u128>);
         add_shift_ops!(LittleEndian<i128>);
         add_shift_ops!(LittleEndian<usize>);
-        add_shift_ops!(LittleEndian<isize>);        
+        add_shift_ops!(LittleEndian<isize>);
     }
 }
 
@@ -115,6 +114,4 @@ mod tests {
         ne1 >>= 5;
         assert_eq!(ne1, be1.into());
     }
-
-
 }

--- a/src/shorthand_types.rs
+++ b/src/shorthand_types.rs
@@ -2,15 +2,15 @@
 
 #![allow(non_camel_case_types)]
 use super::*;
-/// Shorthand for `LittleEndian<u16>` 
+/// Shorthand for `LittleEndian<u16>`
 pub type u16le = LittleEndian<u16>;
-/// Shorthand for `BigEndian<u16>` 
+/// Shorthand for `BigEndian<u16>`
 pub type u16be = BigEndian<u16>;
-/// Shorthand for `LittleEndian<u32>` 
+/// Shorthand for `LittleEndian<u32>`
 pub type u32le = LittleEndian<u32>;
 /// Shorthand for `BigEndian<u32>`
 pub type u32be = BigEndian<u32>;
-/// Shorthand for `LittleEndian<u64>` 
+/// Shorthand for `LittleEndian<u64>`
 pub type u64le = LittleEndian<u64>;
 /// Shorthand for `BigEndian<u64>`
 pub type u64be = BigEndian<u64>;

--- a/src/specific_endian.rs
+++ b/src/specific_endian.rs
@@ -1,20 +1,20 @@
-
 /// Any object implementing `SpecificEndian<T>` can be converted between big and little endian.  Implement this trait to allow for endian conversion by this crate.
-pub trait SpecificEndian<T> where Self: Into<T> + Clone + Copy {
+pub trait SpecificEndian<T>
+where
+    Self: Into<T> + Clone + Copy,
+{
     fn to_big_endian(&self) -> T;
     fn to_little_endian(&self) -> T;
     fn from_big_endian(&self) -> T;
     fn from_little_endian(&self) -> T;
-
 }
 
-#[cfg(feature = "byte_impls")] 
+#[cfg(feature = "byte_impls")]
 mod byte_impls {
     use super::*;
     /// A macro implementing `SpecificEndian<T>` for simple data types where big and little endian forms are the same.
     macro_rules! make_specific_endian_single_byte {
         ($wrap_ty:ty) => {
-
             impl SpecificEndian<$wrap_ty> for $wrap_ty {
                 fn to_big_endian(&self) -> Self {
                     *self
@@ -29,7 +29,7 @@ mod byte_impls {
                     *self
                 }
             }
-        }
+        };
     }
 
     make_specific_endian_single_byte!(u8);
@@ -38,13 +38,12 @@ mod byte_impls {
     make_specific_endian_single_byte!(bool);
 }
 
-#[cfg(feature = "integer_impls")] 
+#[cfg(feature = "integer_impls")]
 mod integer_impls {
     use super::*;
     /// A macro for implementing `SpecificEndian<T>` on types that have endian conversions built into Rust.  Currently, this is the primitive integer types.
     macro_rules! make_specific_endian_integer {
         ($wrap_ty:ty) => {
-
             impl SpecificEndian<$wrap_ty> for $wrap_ty {
                 fn to_big_endian(&self) -> Self {
                     self.to_be()
@@ -59,7 +58,7 @@ mod integer_impls {
                     Self::from_le(*self)
                 }
             }
-        }
+        };
     }
 
     make_specific_endian_integer!(u16);
@@ -74,13 +73,12 @@ mod integer_impls {
     make_specific_endian_integer!(isize);
 }
 
-#[cfg(feature = "float_impls")] 
+#[cfg(feature = "float_impls")]
 mod float_impls {
     use super::*;
     /// Uses .from_bits() and .to_bits() to implement SpecificEndian<T> with Integer types.  Can be used with any type having these methods, but mainly for use with the floats.
     macro_rules! make_specific_endian_float {
         ($wrap_ty:ty) => {
-
             impl SpecificEndian<$wrap_ty> for $wrap_ty {
                 fn to_big_endian(&self) -> Self {
                     Self::from_bits(self.to_bits().to_be())
@@ -95,7 +93,7 @@ mod float_impls {
                     Self::from_bits(self.to_bits().from_little_endian())
                 }
             }
-        }
+        };
     }
 
     make_specific_endian_float!(f32);
@@ -105,19 +103,23 @@ mod float_impls {
 /// A big-endian representation of type `T` that implements `SpecificEndian<T>`.  Data stored in the struct must be converted to big-endian using `::from()` or `.into()`.
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq)]
 #[repr(transparent)]
-pub struct BigEndian<T: SpecificEndian<T>> {pub(crate) _v: T}
+pub struct BigEndian<T: SpecificEndian<T>> {
+    pub(crate) _v: T,
+}
 unsafe impl<T: Send + SpecificEndian<T>> Send for BigEndian<T> {}
 unsafe impl<T: Sync + SpecificEndian<T>> Sync for BigEndian<T> {}
 
-
-impl<T> BigEndian<T> where T: SpecificEndian<T> {
+impl<T> BigEndian<T>
+where
+    T: SpecificEndian<T>,
+{
     /// Returns the raw data stored in the struct.
     pub fn to_bits(&self) -> T {
         self._v
     }
     /// Imports the data raw into a BigEndian<T> struct.
     pub fn from_bits(v: T) -> Self {
-        Self{_v: v}
+        Self { _v: v }
     }
     /// Converts the data to the same type T in host-native endian.
     pub fn to_native(&self) -> T {
@@ -127,26 +129,32 @@ impl<T> BigEndian<T> where T: SpecificEndian<T> {
 
 impl<T: SpecificEndian<T>> From<T> for BigEndian<T> {
     fn from(v: T) -> BigEndian<T> {
-        BigEndian::<T>{_v: v.to_big_endian()}
+        BigEndian::<T> {
+            _v: v.to_big_endian(),
+        }
     }
 }
-
 
 /// A little-endian representation of type `T` that implements `SpecificEndian<T>`.  Data stored in the struct must be converted to little-endian using `::from()` or `.into()`.
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq)]
 #[repr(transparent)]
-pub struct LittleEndian<T: SpecificEndian<T>> {pub(crate) _v: T}
+pub struct LittleEndian<T: SpecificEndian<T>> {
+    pub(crate) _v: T,
+}
 unsafe impl<T: Send + SpecificEndian<T>> Send for LittleEndian<T> {}
 unsafe impl<T: Sync + SpecificEndian<T>> Sync for LittleEndian<T> {}
 
-impl<T> LittleEndian<T> where T: SpecificEndian<T> {
+impl<T> LittleEndian<T>
+where
+    T: SpecificEndian<T>,
+{
     /// Returns the raw data stored in the struct.
     pub fn to_bits(&self) -> T {
         self._v
     }
     /// Imports the data raw into a LittleEndian<T> struct.
     pub fn from_bits(v: T) -> Self {
-        Self{_v: v}
+        Self { _v: v }
     }
     /// Converts the data to the same type T in host-native endian.
     pub fn to_native(&self) -> T {
@@ -156,11 +164,13 @@ impl<T> LittleEndian<T> where T: SpecificEndian<T> {
 
 impl<T: SpecificEndian<T>> From<T> for LittleEndian<T> {
     fn from(v: T) -> LittleEndian<T> {
-        LittleEndian::<T>{_v: v.to_little_endian()}
+        LittleEndian::<T> {
+            _v: v.to_little_endian(),
+        }
     }
 }
 
-#[cfg(feature = "big_endian")] 
+#[cfg(feature = "big_endian")]
 mod big_endian_primatives {
     #[allow(unused_imports)]
     use super::*;
@@ -168,36 +178,47 @@ mod big_endian_primatives {
     #[allow(unused_macros)]
     macro_rules! make_primitive_type_from_be {
         ($wrap_ty:ty) => {
-
             impl From<BigEndian<$wrap_ty>> for $wrap_ty {
                 fn from(v: BigEndian<$wrap_ty>) -> $wrap_ty {
                     v._v.from_big_endian()
                 }
             }
-
-        }
+        };
     }
 
-    #[cfg(feature = "integer_impls")] make_primitive_type_from_be!(bool);
-    #[cfg(feature = "integer_impls")] make_primitive_type_from_be!(u8);
-    #[cfg(feature = "integer_impls")] make_primitive_type_from_be!(i8);
-    #[cfg(feature = "integer_impls")] make_primitive_type_from_be!(u16);
-    #[cfg(feature = "integer_impls")] make_primitive_type_from_be!(i16);
-    #[cfg(feature = "integer_impls")] make_primitive_type_from_be!(u32);
-    #[cfg(feature = "integer_impls")] make_primitive_type_from_be!(i32);
-    #[cfg(feature = "integer_impls")] make_primitive_type_from_be!(u64);
-    #[cfg(feature = "integer_impls")] make_primitive_type_from_be!(i64);
-    #[cfg(feature = "integer_impls")] make_primitive_type_from_be!(u128);
-    #[cfg(feature = "integer_impls")] make_primitive_type_from_be!(i128);
-    #[cfg(feature = "integer_impls")] make_primitive_type_from_be!(usize);
-    #[cfg(feature = "integer_impls")] make_primitive_type_from_be!(isize);
-    #[cfg(feature = "float_impls")] make_primitive_type_from_be!(f32);
-    #[cfg(feature = "float_impls")] make_primitive_type_from_be!(f64);
-    
+    #[cfg(feature = "integer_impls")]
+    make_primitive_type_from_be!(bool);
+    #[cfg(feature = "integer_impls")]
+    make_primitive_type_from_be!(u8);
+    #[cfg(feature = "integer_impls")]
+    make_primitive_type_from_be!(i8);
+    #[cfg(feature = "integer_impls")]
+    make_primitive_type_from_be!(u16);
+    #[cfg(feature = "integer_impls")]
+    make_primitive_type_from_be!(i16);
+    #[cfg(feature = "integer_impls")]
+    make_primitive_type_from_be!(u32);
+    #[cfg(feature = "integer_impls")]
+    make_primitive_type_from_be!(i32);
+    #[cfg(feature = "integer_impls")]
+    make_primitive_type_from_be!(u64);
+    #[cfg(feature = "integer_impls")]
+    make_primitive_type_from_be!(i64);
+    #[cfg(feature = "integer_impls")]
+    make_primitive_type_from_be!(u128);
+    #[cfg(feature = "integer_impls")]
+    make_primitive_type_from_be!(i128);
+    #[cfg(feature = "integer_impls")]
+    make_primitive_type_from_be!(usize);
+    #[cfg(feature = "integer_impls")]
+    make_primitive_type_from_be!(isize);
+    #[cfg(feature = "float_impls")]
+    make_primitive_type_from_be!(f32);
+    #[cfg(feature = "float_impls")]
+    make_primitive_type_from_be!(f64);
 }
-    
 
-#[cfg(feature = "little_endian")] 
+#[cfg(feature = "little_endian")]
 mod little_endian_primatives {
     #[allow(unused_imports)]
     use super::*;
@@ -205,35 +226,47 @@ mod little_endian_primatives {
     #[allow(unused_macros)]
     macro_rules! make_primitive_type_from_le {
         ($wrap_ty:ty) => {
-
             impl From<LittleEndian<$wrap_ty>> for $wrap_ty {
                 fn from(v: LittleEndian<$wrap_ty>) -> $wrap_ty {
                     v._v.from_little_endian()
                 }
             }
-
-        }
+        };
     }
 
-    #[cfg(feature = "integer_impls")] make_primitive_type_from_le!(bool);
-    #[cfg(feature = "integer_impls")] make_primitive_type_from_le!(u8);
-    #[cfg(feature = "integer_impls")] make_primitive_type_from_le!(i8);
-    #[cfg(feature = "integer_impls")] make_primitive_type_from_le!(u16);
-    #[cfg(feature = "integer_impls")] make_primitive_type_from_le!(i16);
-    #[cfg(feature = "integer_impls")] make_primitive_type_from_le!(u32);
-    #[cfg(feature = "integer_impls")] make_primitive_type_from_le!(i32);
-    #[cfg(feature = "integer_impls")] make_primitive_type_from_le!(u64);
-    #[cfg(feature = "integer_impls")] make_primitive_type_from_le!(i64);
-    #[cfg(feature = "integer_impls")] make_primitive_type_from_le!(u128);
-    #[cfg(feature = "integer_impls")] make_primitive_type_from_le!(i128);
-    #[cfg(feature = "integer_impls")] make_primitive_type_from_le!(usize);
-    #[cfg(feature = "integer_impls")] make_primitive_type_from_le!(isize);
-    #[cfg(feature = "float_impls")] make_primitive_type_from_le!(f32);
-    #[cfg(feature = "float_impls")] make_primitive_type_from_le!(f64);
+    #[cfg(feature = "integer_impls")]
+    make_primitive_type_from_le!(bool);
+    #[cfg(feature = "integer_impls")]
+    make_primitive_type_from_le!(u8);
+    #[cfg(feature = "integer_impls")]
+    make_primitive_type_from_le!(i8);
+    #[cfg(feature = "integer_impls")]
+    make_primitive_type_from_le!(u16);
+    #[cfg(feature = "integer_impls")]
+    make_primitive_type_from_le!(i16);
+    #[cfg(feature = "integer_impls")]
+    make_primitive_type_from_le!(u32);
+    #[cfg(feature = "integer_impls")]
+    make_primitive_type_from_le!(i32);
+    #[cfg(feature = "integer_impls")]
+    make_primitive_type_from_le!(u64);
+    #[cfg(feature = "integer_impls")]
+    make_primitive_type_from_le!(i64);
+    #[cfg(feature = "integer_impls")]
+    make_primitive_type_from_le!(u128);
+    #[cfg(feature = "integer_impls")]
+    make_primitive_type_from_le!(i128);
+    #[cfg(feature = "integer_impls")]
+    make_primitive_type_from_le!(usize);
+    #[cfg(feature = "integer_impls")]
+    make_primitive_type_from_le!(isize);
+    #[cfg(feature = "float_impls")]
+    make_primitive_type_from_le!(f32);
+    #[cfg(feature = "float_impls")]
+    make_primitive_type_from_le!(f64);
 }
 
-
-#[cfg(feature = "both_endian")] 
+#[cfg(feature = "both_endian")]
 mod both_endian_primatives {
     use super::*;
     /// Allow conversion directly from `LittleEndian<T>` to `BigEndian<T>` without manually going through native endian.
@@ -251,12 +284,11 @@ mod both_endian_primatives {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     extern crate test;
     use crate::*;
-    use std::mem::size_of;
+    use core::mem::size_of;
 
     #[test]
     fn declare_all() {
@@ -284,35 +316,51 @@ mod tests {
     #[test]
     fn make_struct() {
         #[repr(C)]
-        struct Foo (
+        struct Foo(
             BigEndian<i16>,
             LittleEndian<i16>,
             BigEndian<u16>,
             LittleEndian<u16>,
-
             BigEndian<i32>,
             LittleEndian<i32>,
             BigEndian<u32>,
             LittleEndian<u32>,
-
             BigEndian<i64>,
             LittleEndian<i64>,
             BigEndian<u64>,
             LittleEndian<u64>,
-
             BigEndian<i128>,
             LittleEndian<i128>,
             BigEndian<u128>,
             LittleEndian<u128>,
-
             BigEndian<f32>,
             LittleEndian<f32>,
             BigEndian<f64>,
             LittleEndian<f64>,
-
         );
 
-        let _foo = Foo(0.into(), 1.into(), 2.into(), 3.into(), 4.into(), 5.into(), 6.into(), 7.into(), 8.into(), 9.into(), 10.into(), 11.into(), 12.into(), 13.into(), 14.into(), 15.into(), (0.1).into(), (123.5).into(), (7.8).into(), (12345.4567).into());
+        let _foo = Foo(
+            0.into(),
+            1.into(),
+            2.into(),
+            3.into(),
+            4.into(),
+            5.into(),
+            6.into(),
+            7.into(),
+            8.into(),
+            9.into(),
+            10.into(),
+            11.into(),
+            12.into(),
+            13.into(),
+            14.into(),
+            15.into(),
+            (0.1).into(),
+            (123.5).into(),
+            (7.8).into(),
+            (12345.4567).into(),
+        );
     }
 
     #[test]
@@ -320,8 +368,7 @@ mod tests {
         let be: BigEndian<u64> = 0xfe.into();
         if cfg!(byte_order = "big endian") {
             assert_eq!(be.to_bits(), 0xfe);
-        }
-        else {
+        } else {
             assert_eq!(be.to_bits(), 0xfe00000000000000);
         }
     }
@@ -336,8 +383,7 @@ mod tests {
         let le: LittleEndian<u64> = 0xfe.into();
         if cfg!(byte_order = "big endian") {
             assert_eq!(le.to_bits(), 0xfe00000000000000);
-        }
-        else {
+        } else {
             assert_eq!(le.to_bits(), 0xfe);
         }
     }
@@ -352,13 +398,12 @@ mod tests {
     #[test]
     fn convert_back() {
         let be = BigEndian::from(12345);
-        println!("{}", u64::from(be));
+        assert_eq!(12345, u64::from(be));
     }
 
     #[test]
     fn convert_to_native() {
         let be = BigEndian::from(0xfe);
-        println!("{:x}, {:x}", be._v, be.to_native());
         assert_eq!(0xfe, be.to_native());
     }
 
@@ -384,7 +429,6 @@ mod tests {
     fn inferred_type() {
         let mut be1 = BigEndian::from(1234);
         be1 &= BigEndian::from(5678);
-        println!("{} {} {}", be1, be1.to_bits(), be1.to_native());
         assert_eq!(be1, 1026.into());
     }
 
@@ -392,7 +436,6 @@ mod tests {
     fn inferred_type_fp() {
         let mut be1 = BigEndian::from(1234.5);
         be1 += BigEndian::from(5678.1);
-        println!("{} {} {}", be1, be1.to_bits(), be1.to_native());
         assert_eq!(be1, 6912.6.into());
     }
 
@@ -400,7 +443,6 @@ mod tests {
     fn inferred_type_bigger() {
         let mut be1 = BigEndian::from(0x0feeddcc);
         be1 &= BigEndian::from(0xff00);
-        println!("{} {} {}", be1, be1.to_bits(), be1.to_native());
         assert_eq!(be1, 0xdd00.into());
     }
 
@@ -431,38 +473,44 @@ mod tests {
             fn to_big_endian(&self) -> Self {
                 match self {
                     EndianAwareExample::BigEndianFunction(_v) => *self,
-                    EndianAwareExample::LittleEndianFunction(v) => EndianAwareExample::BigEndianFunction(v.to_big_endian()),
+                    EndianAwareExample::LittleEndianFunction(v) => {
+                        EndianAwareExample::BigEndianFunction(v.to_big_endian())
+                    }
                 }
             }
             fn to_little_endian(&self) -> Self {
                 match self {
                     EndianAwareExample::LittleEndianFunction(_v) => *self,
-                    EndianAwareExample::BigEndianFunction(v) => EndianAwareExample::BigEndianFunction(v.to_little_endian()),
+                    EndianAwareExample::BigEndianFunction(v) => {
+                        EndianAwareExample::BigEndianFunction(v.to_little_endian())
+                    }
                 }
             }
             fn from_big_endian(&self) -> Self {
                 match self {
                     EndianAwareExample::BigEndianFunction(_v) => *self,
-                    EndianAwareExample::LittleEndianFunction(v) => EndianAwareExample::BigEndianFunction(v.to_big_endian()),
+                    EndianAwareExample::LittleEndianFunction(v) => {
+                        EndianAwareExample::BigEndianFunction(v.to_big_endian())
+                    }
                 }
             }
             fn from_little_endian(&self) -> Self {
                 match self {
                     EndianAwareExample::LittleEndianFunction(_v) => *self,
-                    EndianAwareExample::BigEndianFunction(v) => EndianAwareExample::BigEndianFunction(v.to_little_endian()),
+                    EndianAwareExample::BigEndianFunction(v) => {
+                        EndianAwareExample::BigEndianFunction(v.to_little_endian())
+                    }
                 }
             }
-
         }
-        let foo: BigEndian<EndianAwareExample> = EndianAwareExample::LittleEndianFunction(0xf0).into();
+        let foo: BigEndian<EndianAwareExample> =
+            EndianAwareExample::LittleEndianFunction(0xf0).into();
         #[allow(unused_assignments)]
-        let mut value = 0;
-        match foo.to_native() {
-            EndianAwareExample::BigEndianFunction(v) => { println!("be: {:x}", v); value = v }
-            EndianAwareExample::LittleEndianFunction(v) => { println!("le: {:x}", v); value = 0 }
-        }
+        let value = match foo.to_native() {
+            EndianAwareExample::BigEndianFunction(v) => v,
+            // TODO this doesn't seem right? It'll cause the assert to always fail.
+            EndianAwareExample::LittleEndianFunction(_v) => 0,
+        };
         assert_eq!(value, 0x0f000000000000000);
     }
-
 }
-


### PR DESCRIPTION
It only required replacing `std` with `core` and removing all `println`s. The `println`s in the benchmarks have been replaced with `black_box` (which it should have been in the first place because otherwise you're measuring I/O overhead)