### PR TITLE
Fixes #4: add support for `no_std` behind feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ memmap = "0.7"
 
 [features]
 default = ["bitwise", "comparisons", "format", "math_ops",
-    "neg_ops", "shift_ops", "both_endian", "float_impls", "integer_impls", "byte_impls"]
+    "neg_ops", "shift_ops", "both_endian", "float_impls", "integer_impls", "byte_impls", "std"]
 bitwise = ["integer_impls"]
 comparisons = []
 format = []
@@ -31,3 +31,4 @@ both_endian = ["big_endian", "little_endian"]
 float_impls = ["integer_impls"]
 integer_impls = []
 byte_impls = []
+std = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![feature(test)]
 //! Many byte-order-handling libraries focus on providing code to convert to and from big- or little-endian.  However,
 //! this requires users of those libraries to use a lot of explicit logic.  This library uses the Rust type system to


### PR DESCRIPTION
This PR fixes broken support for `no_std` by following the well recognized pattern of default `std` feature, which when not present turns the `#![no_std]` flag in `lib.rs` on. This method do not break unit tests or benchmarks.

Hopefully it can get merged and let nuta/kerla#70 implement ext2 filesystem using this crate.