### PR TITLE
Impl traits based on any T and not just the specifc int/float/binary types

### DIFF
--- a/src/comparison_ops.rs
+++ b/src/comparison_ops.rs
@@ -5,99 +5,39 @@ use core::cmp::Ordering;
 #[allow(unused_imports)]
 use super::*;
 
-/// For types that have PartialEq.
-#[allow(unused_macros)]
-macro_rules! add_equality_ops {
-    ($wrap_ty:ty) => {
-        impl PartialOrd for $wrap_ty {
-            fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-                self.to_native().partial_cmp(&other.to_native())
-            }
-        }
-    };
-}
-
-// The floats can only have PartialOrd, not Ord, because they only have PartialEq and not Eq.
-#[cfg(feature = "float_impls")]
-mod float_comps {
-    use super::*;
-    #[cfg(feature = "big_endian")]
-    mod be {
-        use super::*;
-        add_equality_ops!(BigEndian<f32>);
-        add_equality_ops!(BigEndian<f64>);
-    }
-    #[cfg(feature = "little_endian")]
-    mod le {
-        use super::*;
-        add_equality_ops!(LittleEndian<f32>);
-        add_equality_ops!(LittleEndian<f64>);
+impl<T> PartialOrd for BigEndian<T>
+where
+    T: PartialOrd + SpecificEndian<T>,
+{
+    fn partial_cmp(&self, other: &BigEndian<T>) -> Option<Ordering> {
+        self.to_native().partial_cmp(&other.to_native())
     }
 }
 
-/// For types that implement Eq.
-#[allow(unused_macros)]
-macro_rules! add_full_equality_ops {
-    ($wrap_ty:ty) => {
-        impl Ord for $wrap_ty {
-            fn cmp(&self, other: &Self) -> Ordering {
-                self.to_native().cmp(&other.to_native())
-            }
-        }
-        add_equality_ops!($wrap_ty);
-    };
-}
-
-// We have to separate Ord because f32/64 don't have Eq trait.
-#[cfg(feature = "integer_impls")]
-mod integer_comps {
-    use super::*;
-    #[cfg(feature = "big_endian")]
-    mod be {
-        use super::*;
-        add_full_equality_ops!(BigEndian<u16>);
-        add_full_equality_ops!(BigEndian<i16>);
-        add_full_equality_ops!(BigEndian<u32>);
-        add_full_equality_ops!(BigEndian<i32>);
-        add_full_equality_ops!(BigEndian<u64>);
-        add_full_equality_ops!(BigEndian<i64>);
-        add_full_equality_ops!(BigEndian<u128>);
-        add_full_equality_ops!(BigEndian<i128>);
-        add_full_equality_ops!(BigEndian<usize>);
-        add_full_equality_ops!(BigEndian<isize>);
-    }
-    #[cfg(feature = "little_endian")]
-    mod le {
-        use super::*;
-        add_full_equality_ops!(LittleEndian<u16>);
-        add_full_equality_ops!(LittleEndian<i16>);
-        add_full_equality_ops!(LittleEndian<u32>);
-        add_full_equality_ops!(LittleEndian<i32>);
-        add_full_equality_ops!(LittleEndian<u64>);
-        add_full_equality_ops!(LittleEndian<i64>);
-        add_full_equality_ops!(LittleEndian<u128>);
-        add_full_equality_ops!(LittleEndian<i128>);
-        add_full_equality_ops!(LittleEndian<usize>);
-        add_full_equality_ops!(LittleEndian<isize>);
+impl<T> PartialOrd for LittleEndian<T>
+where
+    T: PartialOrd + SpecificEndian<T>,
+{
+    fn partial_cmp(&self, other: &LittleEndian<T>) -> Option<Ordering> {
+        self.to_native().partial_cmp(&other.to_native())
     }
 }
 
-#[cfg(feature = "byte_impls")]
-mod byte_comps {
-    use super::*;
-    #[cfg(feature = "big_endian")]
-    mod be {
-        use super::*;
-        add_full_equality_ops!(BigEndian<bool>);
-        add_full_equality_ops!(BigEndian<u8>);
-        add_full_equality_ops!(BigEndian<i8>);
+impl<T> Ord for BigEndian<T>
+where
+    T: Ord + SpecificEndian<T>,
+{
+    fn cmp(&self, other: &BigEndian<T>) -> Ordering {
+        self.to_native().cmp(&other.to_native())
     }
-    #[cfg(feature = "little_endian")]
-    mod le {
-        use super::*;
-        add_full_equality_ops!(LittleEndian<bool>);
-        add_full_equality_ops!(LittleEndian<u8>);
-        add_full_equality_ops!(LittleEndian<i8>);
+}
+
+impl<T> Ord for LittleEndian<T>
+where
+    T: Ord + SpecificEndian<T>,
+{
+    fn cmp(&self, other: &LittleEndian<T>) -> Ordering {
+        self.to_native().cmp(&other.to_native())
     }
 }
 

--- a/src/math_ops.rs
+++ b/src/math_ops.rs
@@ -7,8 +7,11 @@ use super::*;
 
 #[allow(unused_macros)]
 macro_rules! add_math_ops {
-    ($wrap_ty:ty) => {
-        impl Add for $wrap_ty {
+    ($wrap_ty:ident) => {
+        impl<T> Add for $wrap_ty<T>
+        where
+            T: Add<Output = T> + SpecificEndian<T>,
+        {
             type Output = Self;
 
             fn add(self, other: Self) -> Self {
@@ -16,13 +19,19 @@ macro_rules! add_math_ops {
             }
         }
 
-        impl AddAssign for $wrap_ty {
+        impl<T> AddAssign for $wrap_ty<T>
+        where
+            T: Add<Output = T> + SpecificEndian<T>,
+        {
             fn add_assign(&mut self, other: Self) {
                 *self = *self + other;
             }
         }
 
-        impl Mul for $wrap_ty {
+        impl<T> Mul for $wrap_ty<T>
+        where
+            T: Mul<Output = T> + SpecificEndian<T>,
+        {
             type Output = Self;
 
             fn mul(self, other: Self) -> Self {
@@ -30,13 +39,19 @@ macro_rules! add_math_ops {
             }
         }
 
-        impl MulAssign for $wrap_ty {
+        impl<T> MulAssign for $wrap_ty<T>
+        where
+            T: Mul<Output = T> + SpecificEndian<T>,
+        {
             fn mul_assign(&mut self, other: Self) {
                 *self = *self * other;
             }
         }
 
-        impl Div for $wrap_ty {
+        impl<T> Div for $wrap_ty<T>
+        where
+            T: Div<Output = T> + SpecificEndian<T>,
+        {
             type Output = Self;
 
             fn div(self, other: Self) -> Self {
@@ -44,20 +59,30 @@ macro_rules! add_math_ops {
             }
         }
 
-        impl DivAssign for $wrap_ty {
+        impl<T> DivAssign for $wrap_ty<T>
+        where
+            T: Div<Output = T> + SpecificEndian<T>,
+        {
             fn div_assign(&mut self, other: Self) {
                 *self = *self / other;
             }
         }
 
-        impl Sub for $wrap_ty {
+        impl<T> Sub for $wrap_ty<T>
+        where
+            T: Sub<Output = T> + SpecificEndian<T>,
+        {
             type Output = Self;
 
             fn sub(self, other: Self) -> Self {
                 Self::from(self.to_native() - other.to_native())
             }
         }
-        impl SubAssign for $wrap_ty {
+
+        impl<T> SubAssign for $wrap_ty<T>
+        where
+            T: Sub<Output = T> + SpecificEndian<T>,
+        {
             fn sub_assign(&mut self, other: Self) {
                 *self = *self - other;
             }
@@ -65,71 +90,8 @@ macro_rules! add_math_ops {
     };
 }
 
-#[cfg(feature = "big_endian")]
-mod be {
-    use super::*;
-    #[cfg(feature = "byte_impls")]
-    mod bytes {
-        use super::*;
-        add_math_ops!(BigEndian<u8>);
-        add_math_ops!(BigEndian<i8>);
-    }
-
-    #[cfg(feature = "integer_impls")]
-    mod integers {
-        use super::*;
-        add_math_ops!(BigEndian<u16>);
-        add_math_ops!(BigEndian<i16>);
-        add_math_ops!(BigEndian<u32>);
-        add_math_ops!(BigEndian<i32>);
-        add_math_ops!(BigEndian<u64>);
-        add_math_ops!(BigEndian<i64>);
-        add_math_ops!(BigEndian<u128>);
-        add_math_ops!(BigEndian<i128>);
-        add_math_ops!(BigEndian<usize>);
-        add_math_ops!(BigEndian<isize>);
-    }
-
-    #[cfg(feature = "float_impls")]
-    mod floats {
-        use super::*;
-        add_math_ops!(BigEndian<f32>);
-        add_math_ops!(BigEndian<f64>);
-    }
-}
-
-#[cfg(feature = "little_endian")]
-mod le {
-    use super::*;
-    #[cfg(feature = "byte_impls")]
-    mod bytes {
-        use super::*;
-        add_math_ops!(LittleEndian<u8>);
-        add_math_ops!(LittleEndian<i8>);
-    }
-
-    #[cfg(feature = "integer_impls")]
-    mod integers {
-        use super::*;
-        add_math_ops!(LittleEndian<u16>);
-        add_math_ops!(LittleEndian<i16>);
-        add_math_ops!(LittleEndian<u32>);
-        add_math_ops!(LittleEndian<i32>);
-        add_math_ops!(LittleEndian<u64>);
-        add_math_ops!(LittleEndian<i64>);
-        add_math_ops!(LittleEndian<u128>);
-        add_math_ops!(LittleEndian<i128>);
-        add_math_ops!(LittleEndian<usize>);
-        add_math_ops!(LittleEndian<isize>);
-    }
-
-    #[cfg(feature = "float_impls")]
-    mod floats {
-        use super::*;
-        add_math_ops!(LittleEndian<f32>);
-        add_math_ops!(LittleEndian<f64>);
-    }
-}
+add_math_ops!(LittleEndian);
+add_math_ops!(BigEndian);
 
 #[cfg(test)]
 mod tests {

--- a/src/neg_ops.rs
+++ b/src/neg_ops.rs
@@ -3,8 +3,11 @@ use super::*;
 use core::ops::Neg;
 
 macro_rules! add_neg_ops {
-    ($wrap_ty:ty) => {
-        impl Neg for $wrap_ty {
+    ($wrap_ty:ident) => {
+        impl<T> Neg for $wrap_ty<T>
+        where
+            T: Neg<Output = T> + SpecificEndian<T>,
+        {
             type Output = Self;
 
             fn neg(self) -> Self {
@@ -14,53 +17,8 @@ macro_rules! add_neg_ops {
     };
 }
 
-#[cfg(feature = "big_endian")]
-mod be {
-    use super::*;
-    #[cfg(feature = "byte_impls")]
-    add_neg_ops!(BigEndian<i8>);
-
-    #[cfg(feature = "integer_impls")]
-    mod integers {
-        use super::*;
-        add_neg_ops!(BigEndian<i16>);
-        add_neg_ops!(BigEndian<i32>);
-        add_neg_ops!(BigEndian<i64>);
-        add_neg_ops!(BigEndian<i128>);
-        add_neg_ops!(BigEndian<isize>);
-    }
-
-    #[cfg(feature = "float_impls")]
-    mod floats {
-        use super::*;
-        add_neg_ops!(BigEndian<f32>);
-        add_neg_ops!(BigEndian<f64>);
-    }
-}
-
-#[cfg(feature = "little_endian")]
-mod le {
-    use super::*;
-    #[cfg(feature = "byte_impls")]
-    add_neg_ops!(LittleEndian<i8>);
-
-    #[cfg(feature = "integer_impls")]
-    mod integers {
-        use super::*;
-        add_neg_ops!(LittleEndian<i16>);
-        add_neg_ops!(LittleEndian<i32>);
-        add_neg_ops!(LittleEndian<i64>);
-        add_neg_ops!(LittleEndian<i128>);
-        add_neg_ops!(LittleEndian<isize>);
-    }
-
-    #[cfg(feature = "float_impls")]
-    mod floats {
-        use super::*;
-        add_neg_ops!(LittleEndian<f32>);
-        add_neg_ops!(LittleEndian<f64>);
-    }
-}
+add_neg_ops!(LittleEndian);
+add_neg_ops!(BigEndian);
 
 #[cfg(test)]
 mod tests {

--- a/src/specific_endian.rs
+++ b/src/specific_endian.rs
@@ -110,11 +110,11 @@ where
     T: SpecificEndian<T>,
 {
     /// Returns the raw data stored in the struct.
-    pub fn to_bits(&self) -> T {
+    pub const fn to_bits(&self) -> T {
         self.0
     }
     /// Imports the data raw into a BigEndian<T> struct.
-    pub fn from_bits(v: T) -> Self {
+    pub const fn from_bits(v: T) -> Self {
         Self(v)
     }
     /// Converts the data to the same type T in host-native endian.
@@ -139,11 +139,11 @@ where
     T: SpecificEndian<T>,
 {
     /// Returns the raw data stored in the struct.
-    pub fn to_bits(&self) -> T {
+    pub const fn to_bits(&self) -> T {
         self.0
     }
     /// Imports the data raw into a LittleEndian<T> struct.
-    pub fn from_bits(v: T) -> Self {
+    pub const fn from_bits(v: T) -> Self {
         Self(v)
     }
     /// Converts the data to the same type T in host-native endian.


### PR DESCRIPTION
This is currently based off #6. I can remove that commit if you want to only merge 1 of both PRs. 

I have not yet implemented this for bitwise operations. 